### PR TITLE
chore: bump NCS CI image to v3.3.0

### DIFF
--- a/ncs.dockerfile
+++ b/ncs.dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 AS base
 WORKDIR /workdir
 
 # Toolchain version argument is required for CI build system tagging
-ARG TOOLCHAIN_VERSION=v3.2.3
+ARG TOOLCHAIN_VERSION=v3.3.0
 
 ARG TARGETARCH
 ARG NCS_VERSION=${TOOLCHAIN_VERSION}
@@ -16,8 +16,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 SHELL [ "/bin/bash", "-euxo", "pipefail", "-c" ]
 
 # You can find a table at
-# https://docs.nordicsemi.com/bundle/ncs-3.2.3/page/nrf/installation/recommended_versions.html
-# NCS v3.2.3 requires Zephyr SDK 0.17.0.
+# https://docs.nordicsemi.com/bundle/ncs-3.3.0/page/nrf/installation/recommended_versions.html
+# NCS v3.3.0 requires Zephyr SDK 0.17.0.
 
 ARG ZEPHYR_SDK_VERSION=0.17.0
 ARG CMAKE_VERSION=3.21.0


### PR DESCRIPTION
## Summary

- Bumps `TOOLCHAIN_VERSION` in `ncs.dockerfile` from `v3.2.3` → `v3.3.0` (released 2026-04-23)
- Python requirements (including `jsonschema`) are fetched dynamically from GitHub — no manual changes needed
- Zephyr SDK 0.17.0 unchanged

## Why

Product 11 (Velo3 nRF54) is moving to NCS v3.3.0. The current CI image (`v3.2.3-v2603d-r46`) fails with `ModuleNotFoundError: No module named 'jsonschema'` when building against v3.3.0.

Products 12 and 13 remain on their `v3.2.3` images — unaffected.

## After merge

The push-to-main CI run will produce `ghcr.io/ridebeeline/fw-build-ncs:v3.3.0-main-rN`. Update `products.mk` product 11 `BUILD_IMAGE` to that tag.