### PR TITLE
add protobuf-compiler

### DIFF
--- a/ncs.dockerfile
+++ b/ncs.dockerfile
@@ -59,7 +59,8 @@ RUN apt-get update -y && \
         liblzma-dev \
         locales \
         git-lfs \
-        ca-certificates && \
+        ca-certificates \
+        protobuf-compiler && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8

--- a/nrf5sdk-15.dockerfile
+++ b/nrf5sdk-15.dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && \
         ninja-build \
         pkg-config \
         libopenblas-dev \
-        libopenblas-base && \
+        libopenblas-base \
+        protobuf-compiler && \
     apt-mark manual libopenblas-base && \
     rm -rf /var/lib/apt/lists/*
 

--- a/nrf5sdk-17.dockerfile
+++ b/nrf5sdk-17.dockerfile
@@ -7,7 +7,7 @@ ARG DESIRED_PYTHON_VERSION
 ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
 RUN apt-get update && \
-apt-get install -y libgl1 libglib2.0-0 cmake && \
+apt-get install -y libgl1 libglib2.0-0 cmake protobuf-compiler && \
 apt-get clean
 
 #

--- a/pylib-emulator.dockerfile
+++ b/pylib-emulator.dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && apt-get -y install \
     libglib2.0-0 \
     cmake \
     lcov \
+    protobuf-compiler \
     && apt-get clean
 
 # Install clang-tidy and clang-format from LLVM apt repos


### PR DESCRIPTION
## Summary
This PR adds protobuf-compiler to all dockerfiles, so we can generate pb.h/c from .proto during configure time

## Why
Part of moving to BCore

## Testing
checked with local tag on NCS, NRF5 and emulator builds 
 ## Notes
