### PR TITLE
add python3 protobuf to emulator

### DIFF
--- a/pylib-emulator.dockerfile
+++ b/pylib-emulator.dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -y && apt-get -y install \
     cmake \
     lcov \
     protobuf-compiler \
+    python3-protobuf \
     && apt-get clean
 
 # Install clang-tidy and clang-format from LLVM apt repos


### PR DESCRIPTION
## Summary
This PR adds python3-protobuf to the emulator build image, because we need it for things like bore_lint and bcore_sanitise_and_coverage.

## Testing
tested with local tag
