### PR TITLE
use compatible protoc version 33.2

### DIFF
--- a/embedded-gcc.dockerfile
+++ b/embedded-gcc.dockerfile
@@ -14,7 +14,7 @@ ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
 # Download tools and prerequisites
 RUN apt-get update && \
-apt-get install -y curl git unzip bzip2 build-essential srecord pkg-config libusb-1.0.0 cmake protobuf-compiler && \
+apt-get install -y curl git unzip bzip2 build-essential srecord pkg-config libusb-1.0.0 cmake && \
 apt-get clean all 
 
 # Download and install the toolchain

--- a/ncs.dockerfile
+++ b/ncs.dockerfile
@@ -59,8 +59,7 @@ RUN apt-get update -y && \
         liblzma-dev \
         locales \
         git-lfs \
-        ca-certificates \
-        protobuf-compiler && \
+        ca-certificates && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
@@ -72,6 +71,12 @@ RUN CMAKE_ARCH=$(uname -m) && \
         -O /tmp/cmake.sh && \
     sh /tmp/cmake.sh --prefix=/usr/local --skip-license && \
     rm /tmp/cmake.sh
+
+# install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+ENV PROTOC_VERSION=33.2
+RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
+    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
 
 
 # --- PYTHON INSTALLATION AND SETUP ---
@@ -100,6 +105,9 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV UV_NO_PROGRESS=1
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
+
+# protobuf compiler dependencies for nanopb. make sure the version is pinned and the same across all build images & python dependencies
+RUN uv pip install protobuf==6.33.2
 
 # --- ZEPHYR SDK INSTALLATION ---
 # This replaces the "Nordic Toolchain Manager". 

--- a/nrf5sdk-15.dockerfile
+++ b/nrf5sdk-15.dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update && \
         ninja-build \
         pkg-config \
         libopenblas-dev \
-        libopenblas-base \
-        protobuf-compiler && \
+        libopenblas-base && \
     apt-mark manual libopenblas-base && \
     rm -rf /var/lib/apt/lists/*
 

--- a/nrf5sdk-17.dockerfile
+++ b/nrf5sdk-17.dockerfile
@@ -7,8 +7,15 @@ ARG DESIRED_PYTHON_VERSION
 ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
 RUN apt-get update && \
-apt-get install -y libgl1 libglib2.0-0 cmake protobuf-compiler && \
+apt-get install -y libgl1 libglib2.0-0 cmake && \
 apt-get clean
+
+# install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+ENV PROTOC_VERSION=33.2
+RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
+    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+
 
 #
 # Install required Python using uv (https://astral.sh/uv/)
@@ -21,9 +28,15 @@ RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH"
 
 RUN uv python install $PYTHON_VERSION
+# the proto compiler depends on python for the nanopb plugin, so we need to make this available
+# it's done here, as in CI no uv sync is done, so this environment would be empty.
+# NOTE: this venv gets mounted and uv sync can run on it. THat will update all packages if an update is available, or remove
+# if they are not in the uv lock file!
+RUN uv venv /home/venv --python $PYTHON_VERSION
 
 # Make this the default uv environment globally and for all projects to be /home/venv 
 # This will be the mount point for the venv named volume
+ENV PATH="/home/venv/bin:$PATH"
 ENV VIRTUAL_ENV=/home/venv
 ENV UV_PROJECT_ENVIRONMENT=/home/venv
 ENV UV_LINK_MODE=copy
@@ -32,3 +45,6 @@ ENV UV_LINK_MODE=copy
 ENV UV_NO_PROGRESS=1
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
+
+# finally, install protobuf. make sure the version is pinned and the same across all builds.
+RUN uv pip install protobuf==6.33.2

--- a/pylib-emulator.dockerfile
+++ b/pylib-emulator.dockerfile
@@ -1,4 +1,3 @@
-# bullseye is the latest stable release of debian
 FROM debian:bookworm-slim
 
 # Toolchain version argument is required for CI build system tagging
@@ -22,12 +21,11 @@ RUN apt-get update -y && apt-get -y install \
     srecord \
     git \
     curl \
+    unzip \
     libgl1 \
     libglib2.0-0 \
     cmake \
     lcov \
-    protobuf-compiler \
-    python3-protobuf \
     && apt-get clean
 
 # Install clang-tidy and clang-format from LLVM apt repos
@@ -48,6 +46,12 @@ RUN apt-get update -y && apt-get -y install \
     && apt-get -y autoremove \
     && apt-get clean
 
+# install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+ENV PROTOC_VERSION=33.2
+RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
+    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+
 #
 # Install required Python using uv (https://astral.sh/uv/)
 #
@@ -59,9 +63,15 @@ RUN sh /uv-installer.sh && rm /uv-installer.sh
 ENV PATH="/root/.local/bin/:$PATH"
 
 RUN uv python install $PYTHON_VERSION
+# the proto compiler depends on python for the nanopb plugin.
+# it's done here, as in CI no uv sync is done, so this environment would be empty.
+# NOTE: this venv gets mounted and uv sync can run on it. THat will update all packages if an update is available, or remove
+# if they are not in the uv lock file!
+RUN uv venv /home/venv --python $PYTHON_VERSION
 
 # Make this the default uv environment globally and for all projects to be /home/venv 
 # This will be the mount point for the venv named volume
+ENV PATH="/home/venv/bin:$PATH"
 ENV VIRTUAL_ENV=/home/venv
 ENV UV_PROJECT_ENVIRONMENT=/home/venv
 ENV UV_LINK_MODE=copy
@@ -70,3 +80,6 @@ ENV UV_LINK_MODE=copy
 ENV UV_NO_PROGRESS=1
 ENV UV_NO_DEV=1
 ENV UV_LOCKED=1
+
+# finally, install protobuf. make sure the version is pinned and the same across all builds.
+RUN uv pip install protobuf==6.33.2


### PR DESCRIPTION
## Summary
This PR pulls in a pinned version of protoc (33.2) instead of the apt-get available one, because that one's too old to be compatible with protobuf's python API 6.33.2

## Why
compatibility with honeypy + python packages

## Testing
local tags

## Notes
