### PR TITLE
Install the correct protoc arch

### DIFF
--- a/ncs.dockerfile
+++ b/ncs.dockerfile
@@ -73,10 +73,18 @@ RUN CMAKE_ARCH=$(uname -m) && \
     rm /tmp/cmake.sh
 
 # install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+# protobuf releases use "x86_64" / "aarch_64" (note the underscore) in artifact names.
 ENV PROTOC_VERSION=33.2
-RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
-    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
-    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        PROTOC_ARCH=x86_64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        PROTOC_ARCH=aarch_64; \
+    else \
+        echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1; \
+    fi && \
+    curl -fLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" && \
+    unzip "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" -d /usr/local && \
+    rm "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
 
 
 # --- PYTHON INSTALLATION AND SETUP ---

--- a/nrf5sdk-17.dockerfile
+++ b/nrf5sdk-17.dockerfile
@@ -3,6 +3,8 @@ FROM ghcr.io/charliebruce/nrf5-docker-build:sdk-17.1.0
 # Toolchain version argument is required for CI build system tagging
 ARG TOOLCHAIN_VERSION=17.1.0
 
+ARG TARGETARCH
+
 ARG DESIRED_PYTHON_VERSION
 ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
@@ -11,10 +13,18 @@ apt-get install -y libgl1 libglib2.0-0 cmake && \
 apt-get clean
 
 # install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+# protobuf releases use "x86_64" / "aarch_64" (note the underscore) in artifact names.
 ENV PROTOC_VERSION=33.2
-RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
-    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
-    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        PROTOC_ARCH=x86_64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        PROTOC_ARCH=aarch_64; \
+    else \
+        echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1; \
+    fi && \
+    curl -fLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" && \
+    unzip "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" -d /usr/local && \
+    rm "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
 
 
 #

--- a/pylib-emulator.dockerfile
+++ b/pylib-emulator.dockerfile
@@ -3,6 +3,8 @@ FROM debian:bookworm-slim
 # Toolchain version argument is required for CI build system tagging
 ARG TOOLCHAIN_VERSION=use-desired-python-version
 
+ARG TARGETARCH
+
 ARG DESIRED_PYTHON_VERSION
 ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
@@ -47,10 +49,18 @@ RUN apt-get update -y && apt-get -y install \
     && apt-get clean
 
 # install protobuf compiler that's compatible with our pinned protobuf python API (6.33.2)
+# protobuf releases use "x86_64" / "aarch_64" (note the underscore) in artifact names.
 ENV PROTOC_VERSION=33.2
-RUN curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
-    && unzip "protoc-${PROTOC_VERSION}-linux-x86_64.zip" -d /usr/local \
-    && rm "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        PROTOC_ARCH=x86_64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        PROTOC_ARCH=aarch_64; \
+    else \
+        echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1; \
+    fi && \
+    curl -fLO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" && \
+    unzip "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" -d /usr/local && \
+    rm "protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
 
 #
 # Install required Python using uv (https://astral.sh/uv/)


### PR DESCRIPTION
Protoc arch should match the target arch for multi-arch builds. 

I ran into issues with sandboxes because both arch installed the x86_64 protoc compiler and rosetta translation wasn't available.