### PR TITLE
Add ARM toolchain bin dirs to PATH

### DIFF
--- a/ncs.dockerfile
+++ b/ncs.dockerfile
@@ -153,6 +153,10 @@ RUN sed -i 's/--show-progress//g' setup.sh && \
 ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk-${ZEPHYR_SDK_VERSION}
 
+# Put the ARM Zephyr toolchain binaries (arm-zephyr-eabi-readelf, etc.) on PATH
+# so build tools can find them without an absolute path.
+ENV PATH="/opt/zephyr-sdk-${ZEPHYR_SDK_VERSION}/arm-zephyr-eabi/bin:$PATH"
+
 #
 # Python dependencies
 # We need both the ncs and the zephyr dependencies!

--- a/nrf5sdk-17.dockerfile
+++ b/nrf5sdk-17.dockerfile
@@ -8,6 +8,10 @@ ARG TARGETARCH
 ARG DESIRED_PYTHON_VERSION
 ENV PYTHON_VERSION=${DESIRED_PYTHON_VERSION}
 
+# Put the ARM GCC toolchain binaries (arm-none-eabi-readelf, etc.) on PATH so
+# build tools can find them without an absolute path.
+ENV PATH="/usr/local/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"
+
 RUN apt-get update && \
 apt-get install -y libgl1 libglib2.0-0 cmake && \
 apt-get clean


### PR DESCRIPTION
## Summary
Build tools expect `arm-none-eabi-readelf` (nrf5) and `arm-zephyr-eabi-readelf` (ncs) to be discoverable on `PATH`. Neither was. This adds the respective toolchain `bin` directories.

- **nrf5sdk-17**: `ENV PATH="/usr/local/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"`
- **ncs**: `ENV PATH="/opt/zephyr-sdk-${ZEPHYR_SDK_VERSION}/arm-zephyr-eabi/bin:$PATH"` (uses the existing ARG so it tracks SDK version bumps)

## Verification
Inspected the locally-built images and confirmed the binaries live exactly where expected and were not previously on `PATH`:

```
nrf5sdk-17: /usr/local/gcc-arm-none-eabi-9-2020-q2-update/bin/arm-none-eabi-readelf  (was NOT ON PATH)
ncs:        /opt/zephyr-sdk-0.17.0/arm-zephyr-eabi/bin/arm-zephyr-eabi-readelf       (was NOT ON PATH)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)